### PR TITLE
Bump the memcache version

### DIFF
--- a/memcached-server/docker-compose.yaml
+++ b/memcached-server/docker-compose.yaml
@@ -2,14 +2,14 @@ version: "3"
 
 services:
   memcached-server:
-    image: library/memcached:1.5
+    image: library/memcached:1.6.5
     ports:
       - 11211:11211
     networks:
       - public
 
   memcached-exporter:
-    image: quay.io/prometheus/memcached-exporter:v0.4.1
+    image: prom/memcached-exporter:v0.6.0
     ports:
       - 9150:9150
     networks:


### PR DESCRIPTION
This was harder to do than expected due to a difference in the port numbers
in the documentation. I've raised this as an issue on the repo

https://github.com/prometheus/memcached_exporter/issues/84

Port 9150 seems to be the one in use when the container starts.