### PR TITLE
Add Push gateway support.

### DIFF
--- a/pushgateway/docker-compose.yaml
+++ b/pushgateway/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  pushgateway:
+    image: prom/pushgateway:v1.2.0
+    ports:
+      - 9091:9091
+    networks:
+      - public
+
+  prometheus:
+    volumes:
+      - ${PWD}/pushgateway/pushgateway.json:/etc/prometheus/targets/pushgateway.json

--- a/pushgateway/pushgateway.json
+++ b/pushgateway/pushgateway.json
@@ -1,0 +1,8 @@
+[
+  {
+    "targets": [ "pushgateway:9091" ],
+    "labels": {
+      "job": "pushgateway"
+    }
+  }
+]


### PR DESCRIPTION
Add optional pushgateway support to the prometheus deployment.

This does *not* set honour_labels as this seems to be
unsupported when configuring the targets via the json
formatted files.

Based with thanks on an earlier PR from @akumor.