### PR TITLE
Require a password for redis access

### DIFF
--- a/redis-server/README.md
+++ b/redis-server/README.md
@@ -66,3 +66,7 @@ This allows you to execute commands you can then view on the dashboards or use
 load testing tools to generate additional traffic.
 
     $ redis-cli ping
+
+By default we require password auth to successfully connect. The default password
+can be found in the [redis docker-compose file](/redis-server/docker-compose.yaml)
+in the `command` section.

--- a/redis-server/docker-compose.yaml
+++ b/redis-server/docker-compose.yaml
@@ -3,6 +3,7 @@ version: "3"
 services:
   redis-server:
     image: library/redis:6.0.1
+    command: "--requirepass slightly-locked"
     ports:
       - 6379:6379
     networks:
@@ -16,6 +17,7 @@ services:
       - public
     command:
       - '--redis.addr=redis://redis-server:6379'
+      - '--redis.password=slightly-locked'
 
   prometheus:
     volumes:


### PR DESCRIPTION
This PR forces redis to require a password before you can send
it commands and configures the redis exporter to send that
password so it can continue to export the metrics.

The password itself is defined in plain text inside the repo so it
should be considered insecure but it's an improvement over the redis
instance being completely open.